### PR TITLE
Added flags to toggle visibility of the prompts on the serial line

### DIFF
--- a/chibi.cpp
+++ b/chibi.cpp
@@ -73,6 +73,18 @@ void chibiInit()
 
 /**************************************************************************/
 /*!
+    Initialize the command echo and prompt display settings
+*/
+/**************************************************************************/
+
+void chibiDisplayFlags(char prompt, char echo)
+{
+	cmd_prompt_flag = prompt;
+	cmd_echo_flag = echo;
+}
+
+/**************************************************************************/
+/*!
     Set the short address of the wireless node. This is the 16-bit "nickname" 
     of your node and what will be used to identify it. 
 */

--- a/chibi.h
+++ b/chibi.h
@@ -53,6 +53,7 @@
 #define BROADCAST_ADDR 0xFFFF
 
 void chibiInit();
+void chibiDisplayFlags(char prompt, char echo);
 void chibiSetShortAddr(uint16_t addr);
 uint16_t chibiGetShortAddr();
 void chibiSetIEEEAddr(uint8_t *ieee_addr);

--- a/src/chb_cmd.c
+++ b/src/chb_cmd.c
@@ -61,6 +61,9 @@ const char cmd_banner[] PROGMEM = "*************** CHIBI *******************";
 const char cmd_prompt[] PROGMEM = "CHIBI >> ";
 const char cmd_unrecog[] PROGMEM = "CHIBI: Command not recognized.";
 
+int cmd_prompt_flag = 1;
+int cmd_echo_flag = 1;
+
 /**************************************************************************/
 /*!
     Generate the main command prompt
@@ -68,6 +71,9 @@ const char cmd_unrecog[] PROGMEM = "CHIBI: Command not recognized.";
 /**************************************************************************/
 static void chb_cmd_display()
 {
+    if(cmd_prompt_flag==0)
+        return;
+
     char buf[50];
 
     Serial.println();
@@ -142,14 +148,20 @@ static void chb_cmd_handler()
         // terminate the msg and reset the msg ptr. then send
         // it to the handler for processing.
         *msg_ptr = '\0';
-        Serial.print("\r\n");
+        if(cmd_echo_flag==1)
+        {
+            Serial.print("\r\n");
+        }
         chb_cmd_parse((char *)msg);
         msg_ptr = msg;
         break;
     
     case '\b':
         // backspace 
-        Serial.print(c);
+        if(cmd_echo_flag==1)
+        {
+            Serial.print(c);
+        }
         if (msg_ptr > msg)
         {
             msg_ptr--;
@@ -162,7 +174,10 @@ static void chb_cmd_handler()
         if ((msg_ptr - msg) < (MAX_MSG_SIZE - 1))
         {
             // normal character entered. add it to the buffer
-            Serial.print(c);
+            if(cmd_echo_flag==1)
+            {
+                Serial.print(c);
+            }
             *msg_ptr++ = c;
         }
         break;


### PR DESCRIPTION
Trying to minimize the traffic on the serial line to improve bandwidth and responsivity, I added a call chibiDisplayFlags that allows to disable most of the outputs on the serial. The default behavior is not change but an additional test is made for basically each character output.